### PR TITLE
Converts project to SDK style

### DIFF
--- a/CentralConfig/CentralConfig.csproj
+++ b/CentralConfig/CentralConfig.csproj
@@ -1,145 +1,122 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{DCE138F0-549D-47B9-82A7-14BF1CF9BED3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CentralConfig</RootNamespace>
-    <AssemblyName>CentralConfig</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFramework>netstandard2.1</TargetFramework>
+
+    <!-- 
+      These were automatically generated for you by the template.
+      You should probably not edit them by hand if you've already published
+      to the Thunderstore
+    -->
+
+    <Product>CentralConfig</Product>
+    <ProjectDepsFileName>$(Product).deps.json</ProjectDepsFileName>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/ImpulsiveLad/CentralConfig/</RepositoryUrl>
+    <RootNamespace>$(Product)</RootNamespace>
+    <TargetName>$(Product)</TargetName>
+
+    <!--
+      Except this, you should keep this up to date with your publishing tags
+    -->
+
+    <Version>1.0.0</Version>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
+  <!--
+    Don't mess with anything below this line, it is required to build via 
+    github actions. If you are referencing other DLLs in your project than the
+    base game or unity DLLs they will need to be available via NUGET or copied
+    directly into your repo (which is pretty bad form) to build properly unless
+    they already exist on github in which case you can use submodules to track
+    the reference instead.
+  -->
+
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" Publicize="true">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="com.adibtw.loadstone-publicized, Version=0.1.14.0, Culture=neutral, processorArchitecture=MSIL">
+    <PackageReference
+      Include="BepInEx.Analyzers"
+      PrivateAssets="all"
+      Version="1.*"
+    />
+    <PackageReference
+      Include="BepInEx.Core"
+      Version="5.4.*"
+    />
+    <PackageReference
+      Include="LethalCompany.GameLibs.Steam"
+      Version="61.0.0-ngd.0"
+    />
+    <PackageReference
+      Include="UnityEngine.Modules"
+      IncludeAssets="compile"
+      Version="2023.2.4"
+    />
+
+    <!--
+      When adding additional references, ensure you use <Private>false</Private> to
+      ensure the DLL is explicitly NOT copied to the output directory. This is because
+      the DLLs are already included in the game and will be loaded from there.
+
+      Further, if the DLL is not included as part of the game, you should be using a
+      Dependency in your thunderstore.toml file to ensure the DLL is available to the
+      game when your mod is loaded.
+
+      Example: <Reference Include="Assembly-CSharp.dll" Private="false" />
+    -->
+  </ItemGroup>
+
+  <ItemGroup>
+
+    <Reference
+      Include="com.adibtw.loadstone-publicized, Version=0.1.14.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Downloads\com.adibtw.loadstone-publicized.dll</HintPath>
     </Reference>
-    <Reference Include="com.sigurd.csync, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+
+    <Reference
+      Include="com.sigurd.csync, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Downloads\com.sigurd.csync.dll</HintPath>
     </Reference>
+
     <Reference Include="Diversity">
       <HintPath>..\..\..\..\Downloads\Diversity.dll</HintPath>
     </Reference>
-    <Reference Include="Facepunch.Steamworks.Win64, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Facepunch.Steamworks.Win64.dll</HintPath>
-    </Reference>
+
     <Reference Include="FootballEntity" Publicize="true">
       <HintPath>..\..\..\..\Downloads\FootballEntity.dll</HintPath>
     </Reference>
+
     <Reference Include="LethalBestiary">
       <HintPath>..\..\..\..\Downloads\LethalBestiary.dll</HintPath>
     </Reference>
-    <Reference Include="LethalLevelLoader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+
+    <Reference
+      Include="LethalLevelLoader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Downloads\LethalLevelLoader.dll</HintPath>
     </Reference>
+
     <Reference Include="LethalLib, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Downloads\LethalLib.dll</HintPath>
     </Reference>
+
     <Reference Include="LethalUtilities-publicized">
       <HintPath>..\..\..\..\Downloads\LethalUtilities-publicized.dll</HintPath>
     </Reference>
+
     <Reference Include="PintoBoy">
       <HintPath>..\..\..\..\Downloads\PintoBoy.dll</HintPath>
     </Reference>
+
     <Reference Include="RollingGiant">
       <HintPath>..\..\..\..\Downloads\RollingGiant.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>..\..\Arachnophilia\Arachnophilia\bin\Debug\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
+
     <Reference Include="WeatherRegistry">
       <HintPath>..\..\..\..\Downloads\WeatherRegistry.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Compat.cs" />
-    <Compile Include="DungeonConfig.cs" />
-    <Compile Include="Misc.cs" />
-    <Compile Include="MoonConfig.cs" />
-    <Compile Include="ConfigAider.cs" />
-    <Compile Include="NetworkingStuff.cs" />
-    <Compile Include="Plugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ResetChanger.cs" />
-    <Compile Include="TagConfig.cs" />
-    <Compile Include="WeatherConfig.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-  </Target>
+
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Changes:
- SDK Style project for modern IDEs
- References BepinEx/Unity Nuget packages instead of local files
- References NetStandard 2.1 which is the correct version for LethalCompany

I can't test the build process because I don't have your local, specific references but I kept them the same and the only build errors I got were 290 type not found errors from the referenced assemblies and a duplicate attribute which is solved by cleaning your cache in the /obj/ folder, specifically by deleting this whole folder so it regenerates the files inside.

Things to note:
- Your original project seemed to lack a version field at all so I went with 1.0.0
- Test this by downloading this branch and trying to compile it and making sure it all works before merging