### PR TITLE
WeatherRegistry fixes

### DIFF
--- a/CentralConfig/CentralConfig.csproj
+++ b/CentralConfig/CentralConfig.csproj
@@ -20,16 +20,16 @@
     <PackageReference Include="BepInEx.Core" Version="5.4.*" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="61.0.0-ngd.0" />
     <PackageReference Include="UnityEngine.Modules" IncludeAssets="compile" Version="2023.2.4" />
+    <PackageReference Include="Sigurd.BepInEx.CSync" Version="5.0.1" />
+    <PackageReference Include="IAmBatby.LethalLevelLoader" Version="1.3.13" />
+    <PackageReference Include="Evaisa.LethalLib" Version="0.16.1" />
+    <PackageReference Include="mrov.WeatherRegistry" Version="*-*" Publicize="true" PrivateAssets="true"/>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="com.adibtw.loadstone, Version=0.1.14.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\Downloads\com.adibtw.loadstone.dll</HintPath>
-    </Reference>
-    <Reference Include="com.sigurd.csync, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Downloads\com.sigurd.csync.dll</HintPath>
     </Reference>
     <Reference Include="Diversity Remastered" Publicize="true">
       <HintPath>..\..\..\..\Downloads\Diversity Remastered.dll</HintPath>
@@ -43,14 +43,6 @@
     <Reference Include="LethalBestiary">
       <HintPath>..\..\..\..\Downloads\LethalBestiary.dll</HintPath>
     </Reference>
-    <Reference Include="LethalLevelLoader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Downloads\LethalLevelLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalLib, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Downloads\LethalLib.dll</HintPath>
-    </Reference>
     <Reference Include="LethalUtilities" Publicize="true">
       <HintPath>..\..\..\..\Downloads\LethalUtilities.dll</HintPath>
     </Reference>
@@ -59,9 +51,6 @@
     </Reference>
     <Reference Include="RollingGiant">
       <HintPath>..\..\..\..\Downloads\RollingGiant.dll</HintPath>
-    </Reference>
-    <Reference Include="WeatherRegistry" Publicize="true">
-      <HintPath>..\..\..\..\Downloads\WeatherRegistry.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/CentralConfig/Compat.cs
+++ b/CentralConfig/Compat.cs
@@ -25,25 +25,13 @@ namespace CentralConfig
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         public static List<string> GetAllWeathersWithWR()
         {
-            List<string> weatherlist = WeatherManager.RegisteredWeathers.Cast<Weather>().Select(w => w.ToString()).ToList();
-            for (int i = 0; i < weatherlist.Count; i++)
-            {
-                weatherlist[i] = weatherlist[i].Replace(" (WeatherRegistry.Weather)", "");
-            }
-            return weatherlist;
+            return WeatherManager.Weathers.Select(weather => weather.Name).ToList();
         }
+
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        public static float GetWRWeatherMultiplier(SelectableLevel level)
+        public static float GetWRWeatherMultiplier()
         {
-            if (WeatherManager.currentWeathers._currentWeathers.ContainsKey(level))
-            {
-                Weather currentweather = WeatherManager.GetWeather(level.currentWeather);
-                return currentweather.ScrapAmountMultiplier;
-            }
-            else
-            {
-                return 1f;
-            }
+            return WeatherManager.GetCurrentLevelWeather().ScrapAmountMultiplier;
         }
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         public static void RemoveWRScrapMultiplierHardSet()

--- a/CentralConfig/DungeonConfig.cs
+++ b/CentralConfig/DungeonConfig.cs
@@ -1164,7 +1164,7 @@ namespace CentralConfig
                 if (!FMCompatibility.enabled)
                     __instance.scrapValue = Mathf.RoundToInt(80 * CurrentMultiplier * 2.5f);
                 else if (FMCompatibility.enabled && WRCompatibility.enabled)
-                    __instance.scrapValue = Mathf.RoundToInt(__instance.scrapValue * CurrentMultiplier * 2.5f / WRCompatibility.GetWRWeatherMultiplier(LevelManager.CurrentExtendedLevel.SelectableLevel));
+                    __instance.scrapValue = Mathf.RoundToInt(__instance.scrapValue * CurrentMultiplier * 2.5f / WRCompatibility.GetWRWeatherMultiplier());
                 else if (FMCompatibility.enabled && !WRCompatibility.enabled)
                     __instance.scrapValue = Mathf.RoundToInt(__instance.scrapValue * CurrentMultiplier * 2.5f);
                 ScanNodeProperties LungScanNode = __instance.gameObject.GetComponentInChildren<ScanNodeProperties>();

--- a/CentralConfig/NetworkingStuff.cs
+++ b/CentralConfig/NetworkingStuff.cs
@@ -132,7 +132,7 @@ namespace CentralConfig
             }
             else if (WRCompatibility.enabled)
             {
-                scrapvaluemultiplier *= WRCompatibility.GetWRWeatherMultiplier(LevelManager.CurrentExtendedLevel.SelectableLevel);
+                scrapvaluemultiplier *= WRCompatibility.GetWRWeatherMultiplier();
             }
             if (CentralConfig.SyncConfig.ScaleScrapValueByPlayers)
             {

--- a/CentralConfig/WeatherConfig.cs
+++ b/CentralConfig/WeatherConfig.cs
@@ -69,7 +69,7 @@ namespace CentralConfig
                 List<string> AllWeatherTypes = Enum.GetValues(typeof(LevelWeatherType)).Cast<LevelWeatherType>().Select(w => w.ToString()).ToList(); ;
                 if (WRCompatibility.enabled)
                 {
-                    AllWeatherTypes.AddRange(WRCompatibility.GetAllWeathersWithWR());
+                    AllWeatherTypes = WRCompatibility.GetAllWeathersWithWR();
                 }
                 List<string> ignoreListEntries = ConfigAider.SplitStringsByDaComma(CentralConfig.SyncConfig.BlacklistWeathers.Value).Select(entry => ConfigAider.CauterizeString(entry)).ToList();
 
@@ -184,7 +184,7 @@ namespace CentralConfig
             List<string> AllWeatherTypes = Enum.GetValues(typeof(LevelWeatherType)).Cast<LevelWeatherType>().Select(w => w.ToString()).ToList(); ;
             if (WRCompatibility.enabled)
             {
-                AllWeatherTypes.AddRange(WRCompatibility.GetAllWeathersWithWR());
+                AllWeatherTypes = WRCompatibility.GetAllWeathersWithWR();
             }
             List<string> ignoreListEntries = ConfigAider.SplitStringsByDaComma(CentralConfig.SyncConfig.BlacklistWeathers.Value).Select(entry => ConfigAider.CauterizeString(entry)).ToList();
 


### PR DESCRIPTION
This PR aims to introduce these changes:

- changed all possible mod references to use Nuget packages
- `GetAllWeathersWithWR()` returns a list of all weathers registered in WeatherRegistry (this includes clear and vanilla ones), changed how it's handled in `WeatherConfig` to replace the list rather than append it
- `GetWRWeatherMultiplier()` only performed checks for current level, which can replace `WeatherManger.currentWeathers.ContainsKey` with `WeatherManager.GetCurrentLevelWeather`