### PR TITLE
(fix) CentralConfig changing WeatherRegistry's config values

### DIFF
--- a/CentralConfig/Compat.cs
+++ b/CentralConfig/Compat.cs
@@ -36,7 +36,7 @@ namespace CentralConfig
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         public static void RemoveWRScrapMultiplierHardSet()
         {
-            ConfigManager.UseScrapMultipliers.Value = false;
+            WeatherRegistry.Settings.ScrapMultipliers = false;
         }
     }
     public static class ImperiumCompatibility


### PR DESCRIPTION
This pull request includes a change to the `CentralConfig/Compat.cs` that replaces `ConfigManager.UseScrapMultipliers.Value` with `WeatherRegistry.Settings.ScrapMultipliers`.

Right now CentralConfig changes WeatherRegistry's config values, which creates confusion for users:
- https://discord.com/channels/1168655651455639582/1203871322841808906/1320761554206982194
- https://github.com/AndreyMrovol/LethalWeatherRegistry/issues/13

I've made a change to WeatherRegistry: instead of directly referencing `ConfigManager`, the scrap spawning patch references `Settings` class: https://github.com/AndreyMrovol/LethalWeatherRegistry/commit/ff38ccbb6c0e109db0476cb0df054581b42120eb

By changing *that* value you're gonna achieve the same result without the "fucky-wucky" that's happening right now 😅